### PR TITLE
Fix system tray context menu for OpenSUSE KDE4

### DIFF
--- a/Qt-SESAM/mainwindow.cpp
+++ b/Qt-SESAM/mainwindow.cpp
@@ -250,7 +250,6 @@ MainWindow::MainWindow(QWidget *parent)
   d->masterPasswordInvalidationTimer.setSingleShot(true);
   d->masterPasswordInvalidationTimer.setTimerType(Qt::VeryCoarseTimer);
 
-  d->trayIcon.show();
   QObject::connect(&d->trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), SLOT(trayIconActivated(QSystemTrayIcon::ActivationReason)));
   QMenu *trayMenu = new QMenu(AppName);
   d->actionShow = trayMenu->addAction(tr("Minimize window"));
@@ -266,6 +265,7 @@ MainWindow::MainWindow(QWidget *parent)
   QAction *actionQuit = trayMenu->addAction(tr("Quit"));
   QObject::connect(actionQuit, SIGNAL(triggered(bool)), SLOT(close()));
   d->trayIcon.setContextMenu(trayMenu);
+  d->trayIcon.show();
 
 #ifdef QT_DEBUG
 #ifdef WIN32


### PR DESCRIPTION
The context menu was empty (running OpenSUSE 13.2 with KDE4). As the documentation for QSystemTrayIcon (http://doc.qt.io/qt-5/qsystemtrayicon.html) states "To add a system tray entry, create a QSystemTrayIcon object, call setContextMenu() to provide a context menu for the icon, and call show() to make it visible in the system tray.", I modified the tray icon code accordingly. Afterwards the Menu was displayed correctly.

Maybe this also has an effect on ola-ct/Qt-SESAM#44?
