### PR TITLE
Fix compilation on Qt 5.3 from debian jessie

### DIFF
--- a/Qt-SESAM/logger.cpp
+++ b/Qt-SESAM/logger.cpp
@@ -25,6 +25,7 @@
 #include <QDateTime>
 #include <QStandardPaths>
 #include <QFile>
+#include <QtGlobal>
 
 class LoggerPrivate {
 public:
@@ -71,7 +72,11 @@ void Logger::log(const QString &message)
       d->file.flush();
     }
     else {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
       qDebug().noquote().nospace() << logMsg;
+#else
+      qDebug().nospace() << logMsg;
+#endif
     }
   }
 }


### PR DESCRIPTION
The member function `QDebug::nospace()` was introduced with Qt 5.4. Work
around compilation with older versions of Qt by not using `noquote()`.

Broken since 91759fcf (Improved `Logger`., 2016-01-18).
