### PR TITLE
Qt-SESAM: Fix compilation due to wrong translation file path

### DIFF
--- a/Qt-SESAM/QtSESAM_translations.qrc
+++ b/Qt-SESAM/QtSESAM_translations.qrc
@@ -1,5 +1,5 @@
 <RCC>
     <qresource prefix="/translations">
-        <file alias="QtSESAM_de.qm">translations/QtSESAM_de.qm</file>
+        <file alias="QtSESAM_de.qm">translations/QtSESAM_de.ts</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Currently when compiling you get

/usr/lib/qt5/bin/rcc -name QtSESAM ../../Qt-SESAM/QtSESAM.qrc -o qrc_QtSESAM.cpp
/usr/lib/qt5/bin/rcc -name QtSESAM_translations ../../Qt-SESAM/QtSESAM_translations.qrc -o qrc_QtSESAM_translations.cpp
RCC: Error in '../../Qt-SESAM/QtSESAM_translations.qrc': Cannot find file 'translations/QtSESAM_de.qm'
make[1]: *** [Makefile:546: qrc_QtSESAM_translations.cpp] Fehler 1
make[1]: *** Es wird auf noch nicht beendete Prozesse gewartet....
make[1]: Verzeichnis „/home/firma/devel/Qt-SESAM/build/Qt-SESAM“ wird verlassen
make: *** [Makefile:178: sub-Qt-SESAM-make_first-ordered] Fehler 2

And that is due to the erroneous file path in QtSESAM_translations.qrc.